### PR TITLE
fix: remove position column usage on change (issue #2)

### DIFF
--- a/src/Models/Entity.php
+++ b/src/Models/Entity.php
@@ -277,20 +277,6 @@ class Entity extends Eloquent implements EntityInterface
     {
         parent::boot();
 
-        static::saving(static function (Entity $entity) {
-            if ($entity->isDirty($entity->getPositionColumn())) {
-                $latest = static::getLatestPosition($entity);
-
-                if (!$entity->isMoved) {
-                    $latest--;
-                }
-
-                $entity->position = max(0, min($entity->position, $latest));
-            } elseif (!$entity->exists) {
-                $entity->position = static::getLatestPosition($entity);
-            }
-        });
-
         // When entity is created, the appropriate
         // data will be put into the closure table.
         static::created(static function (Entity $entity) {
@@ -305,12 +291,6 @@ class Entity extends Eloquent implements EntityInterface
 
         static::saved(static function (Entity $entity) {
             $parentIdChanged = $entity->isDirty($entity->getParentIdColumn());
-            
-            if ($parentIdChanged || $entity->isDirty($entity->getPositionColumn())) {
-                $entity->timestamps = false;
-                $entity->reorderSiblings();
-                $entity->timestamps = true;
-            }
 
             if ($entity->closure->ancestor === null) {
                 $primaryKey = $entity->getKey();


### PR DESCRIPTION
Esse PR faz uma modificação no pacote de closure-table para remover o uso da coluna `position` ao realizar alguma alteração no `node`.

Esse PR quebra vários métodos do pacote que não são utilizados por nossas aplicações hoje. O que usamos é a criação/alteração de linhas na tabela `node_closures` e o método descendants/descendantsOf.

Os métodos quebrados utilizam a coluna position, quais não funcionariam hoje em dia já que os nodes criados antes da closure table não possuem position definida.

---

fix: #2